### PR TITLE
Rename ast-related variables in case parser

### DIFF
--- a/lib/visualize_ruby/parser/case.rb
+++ b/lib/visualize_ruby/parser/case.rb
@@ -3,22 +3,23 @@ module VisualizeRuby
     class Case < Base
       # @return [Array<VisualizeRuby::Node>, Array<VisualizeRuby::Edge>]
       def parse
-        condition, *_whens, _else = @ast.children
-        condition_node = Node.new(ast: condition, type: :decision)
+        ast_condition_node, *ast_when_nodes, ast_else_node = @ast.children
+        condition_node = Node.new(ast: ast_condition_node, type: :decision)
         nodes << condition_node
-        _whens.each do |_when|
-          edge_name, actions = _when.children
+
+        ast_when_nodes.each do |ast_when_node|
+          edge_name, actions = ast_when_node.children
           action_nodes, action_edges = Parser.new(ast: actions).parse
           edges << Edge.new(name:  AstHelper.new(edge_name).description, nodes: [condition_node, action_nodes.first])
           nodes.concat(action_nodes)
           edges.concat(action_edges)
         end
 
-        if _else
-          _else_node = Node.new(ast: _else, type: :action)
-          _else_edge = Edge.new(name: "else", nodes: [condition_node, _else_node])
-          nodes << _else_node
-          edges << _else_edge
+        if ast_else_node
+          else_node = Node.new(ast: ast_else_node, type: :action)
+          else_edge = Edge.new(name: "else", nodes: [condition_node, else_node])
+          nodes << else_node
+          edges << else_edge
         end
 
         return nodes, edges


### PR DESCRIPTION
My initial motivation to suggest you to rename these variables are based on:

1) On line 17 of `parser/case.rb` we have weird-looking statement:

```ruby
if _else
  ...
end
```

So it's awkward to understand because `_else` variable calculates to `true` side of `if`, which is confusing. 

2) According to the [ruby style guide rule](https://github.com/rubocop-hq/ruby-style-guide#trailing-underscore-variables) variables with underscore at the beginning mean that variable is "unused variable, but the assignment provides us with useful information". But here in the case parser we have `_whens`, `_else`, `_else_node` and `_else_edge` variables which are all actually used.

So my suggestion:

1) Use ast_ prefix for variables which hold internal AST::Parser objects like: `ast_condition_node`, `ast_else_node`, `ast_when_nodes`
2) Do not use underscore in names for `_else_node` variable and `_else_edge` variables and all variables which hold VisualizeRuby domain objects. 

Will be happy to discuss this topic and hear your thoughts here.